### PR TITLE
Memory error fix

### DIFF
--- a/cronjobs.txt
+++ b/cronjobs.txt
@@ -4,7 +4,8 @@
 0 0 * * * jsub -N cron-wiki-2 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 51 100
 0 0 * * * jsub -N cron-wiki-3 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 101 150
 0 0 * * * jsub -N cron-wiki-4a -once -quiet abstract-wikipedia-data-science/fetch_content.sh 151 166
-0 0 * * * jsub -N cron-wiki-4b -once -quiet abstract-wikipedia-data-science/fetch_content.sh 167 200
+0 0 * * * jsub -N cron-wiki-4b -once -quiet abstract-wikipedia-data-science/fetch_content.sh 167 167
+0 0 * * * jsub -N cron-wiki-4c -once -quiet abstract-wikipedia-data-science/fetch_content.sh 168 200
 0 0 * * * jsub -N cron-wiki-5a -once -quiet abstract-wikipedia-data-science/fetch_content.sh 201 221
 0 0 * * * jsub -N cron-wiki-5b -once -quiet abstract-wikipedia-data-science/fetch_content.sh 222 250
 0 0 * * * jsub -N cron-wiki-6 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 251 300
@@ -15,8 +16,8 @@
 0 0 * * * jsub -N cron-wiki-11 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 501 550
 0 0 * * * jsub -N cron-wiki-12 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 551 600
 0 0 * * * jsub -N cron-wiki-13 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 601 690
-0 0 * * * jsub -N cron-wiki-14a -once -quiet abstract-wikipedia-data-science/fetch_content.sh 691 695
-0 0 * * * jsub -N cron-wiki-14b -once -quiet abstract-wikipedia-data-science/fetch_content.sh 696 717
+0 0 * * * jsub -N cron-wiki-14a -once -quiet abstract-wikipedia-data-science/fetch_content.sh 691 696
+0 0 * * * jsub -N cron-wiki-14b -once -quiet abstract-wikipedia-data-science/fetch_content.sh 697 717
 0 0 * * * jsub -N cron-wiki-15 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 718 750
 0 0 * * * jsub -N cron-wiki-16 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 751 800
 

--- a/cronjobs.txt
+++ b/cronjobs.txt
@@ -14,10 +14,10 @@
 0 0 * * * jsub -N cron-wiki-10 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 451 500
 0 0 * * * jsub -N cron-wiki-11 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 501 550
 0 0 * * * jsub -N cron-wiki-12 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 551 600
-0 0 * * * jsub -N cron-wiki-13 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 601 650
-0 0 * * * jsub -N cron-wiki-14a -once -quiet abstract-wikipedia-data-science/fetch_content.sh 651 695
-0 0 * * * jsub -N cron-wiki-14b -once -quiet abstract-wikipedia-data-science/fetch_content.sh 696 700
-0 0 * * * jsub -N cron-wiki-15 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 701 750
+0 0 * * * jsub -N cron-wiki-13 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 601 690
+0 0 * * * jsub -N cron-wiki-14a -once -quiet abstract-wikipedia-data-science/fetch_content.sh 691 695
+0 0 * * * jsub -N cron-wiki-14b -once -quiet abstract-wikipedia-data-science/fetch_content.sh 696 717
+0 0 * * * jsub -N cron-wiki-15 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 718 750
 0 0 * * * jsub -N cron-wiki-16 -once -quiet abstract-wikipedia-data-science/fetch_content.sh 751 800
 
 0 2 * * * jsub -N cron-db -once -quiet abstract-wikipedia-data-science/db_script.sh

--- a/db_script.py
+++ b/db_script.py
@@ -38,7 +38,7 @@ def get_dbs():
         conn.close()
         return ret
     except pymysql.err.OperationalError as err:
-        print(err)
+        print('Failure: please use only in Toolforge environment')
         exit(1)
 
 

--- a/fetch_content.py
+++ b/fetch_content.py
@@ -29,13 +29,13 @@ def get_wiki_list(start_idx, end_idx):
         exit(1)
 
 
-def save_content(wiki, data_list):
+def save_content(wiki, data_list, in_api, in_database):
 
     data_df = pd.DataFrame(data_list, columns=['id', 'title', 'url', 'length', 'content', 'content_model', 'touched', 'lastrevid'])
 
-    query = ("insert into Scripts(dbname, page_id, title, sourcecode, touched, in_api, length, content_model, lastrevid, url) "
-             "             values(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)\n"
-             "on duplicate key update title = %s, sourcecode = %s, touched = %s, in_api = %s, "
+    query = ("insert into Scripts(dbname, page_id, title, sourcecode, touched, in_api, in_database, length, content_model, lastrevid, url) "
+             "             values(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)\n"
+             "on duplicate key update title = %s, sourcecode = %s, touched = %s, in_api = %s, in_database = %s,"
              "length = %s, content_model = %s, lastrevid = %s, url = %s, is_missed=%s"
              )
     try:
@@ -47,8 +47,8 @@ def save_content(wiki, data_list):
                 time = elem['touched'].replace('T', ' ').replace('Z', ' ')
                 cur.execute(query,
                             [dbname, elem['id'], 
-                            elem['title'], elem['content'], time, 1, elem['length'], elem['content_model'], elem['lastrevid'], elem['url'],
-                            elem['title'], elem['content'], time, 1, elem['length'], elem['content_model'], elem['lastrevid'], elem['url'], 0])
+                            elem['title'], elem['content'], time, in_api, in_database, elem['length'], elem['content_model'], elem['lastrevid'], elem['url'],
+                            elem['title'], elem['content'], time, in_api, in_database, elem['length'], elem['content_model'], elem['lastrevid'], elem['url'], 0])
         conn.commit()
         conn.close()
     except pymysql.err.OperationalError as err:
@@ -165,7 +165,7 @@ def get_contents(wikis, revise=False):
                 cnt_data_list += len(data_list)
                 cnt_missed += len(missed)
                 save_missed_content(wiki, missed)
-                save_content(wiki, data_list)
+                save_content(wiki, data_list, 1, 0)
                 print(cnt_data_list, 'pages loaded...')
                 data_list, missed = [], []
 
@@ -209,7 +209,7 @@ def get_db_map(wikis=[], dbs=[]):
     return db_map, placeholders
 
 
-def get_pages(df):
+def get_pages(df, in_api, in_database):
     '''
     df columns: page_id, dbname, wiki
     dbname not required
@@ -257,7 +257,7 @@ def get_pages(df):
                 missed.append([pageid])
                 print("Miss:", pageid, "from wiki:", wiki, "\n", err)
 
-        save_content(wiki, data_list)
+        save_content(wiki, data_list, in_api, in_database)
         save_missed_content(wiki, missed)
         print("All pages loaded for %s. Missed: %d, Loaded: %d" \
             %(wiki, len(missed), len(data_list)))
@@ -281,25 +281,8 @@ def get_missed_contents(wikis):
         exit(1)
 
     df['wiki'] = df['dbname'].map(db_map)
-    get_pages(df)
+    get_pages(df, 1, 0)
     print("Done loading missed pages!")
-
-def remove_missed_contents(wikis):
-    
-    db_map, placeholders = get_db_map(wikis=wikis)
-    query = ("delete from Scripts where dbname in (%s) and in_api=1 and is_missed=1" % placeholders)
-    
-    try:
-        conn = toolforge.toolsdb(DATABASE_NAME)
-        with conn.cursor() as cur:
-            cur.execute(query, list(db_map.keys()))
-        conn.commit()
-        conn.close()
-    except pymysql.err.OperationalError as err:
-        print('Failure: please use only in Toolforge environment')
-        exit(1)
-    
-    print('Removed redundant rows.')
 
 
 if __name__ == "__main__":
@@ -329,6 +312,4 @@ if __name__ == "__main__":
     
     wikis = get_wiki_list(start_idx, end_idx)
     get_contents(wikis)
-    get_missed_contents(wikis=wikis)
-    remove_missed_contents(wikis)
-    
+    get_missed_contents(wikis=wikis)    

--- a/fetch_content.py
+++ b/fetch_content.py
@@ -115,7 +115,7 @@ def get_contents(wikis, revise=False):
             params = {'action':'query',
                     'generator':'allpages',
                     'gapnamespace':828,
-                    'gaplimit':'max',
+                    'gaplimit':300,
                     'format':'json',
                     'prop':'info',
                     'inprop':'url',

--- a/fetch_content.py
+++ b/fetch_content.py
@@ -52,8 +52,11 @@ def save_content(wiki, data_list):
         conn.commit()
         conn.close()
     except pymysql.err.OperationalError as err:
-        print(err)
+        print('Failure: please use only in Toolforge environment')
         exit(1)
+    except Exception as err:
+        print('Error saving pages from',wiki)
+        print(err)
 
 
 def save_missed_content(wiki, missed):
@@ -75,7 +78,7 @@ def save_missed_content(wiki, missed):
         conn.commit()
         conn.close()
     except pymysql.err.OperationalError as err:
-        print(err)
+        print('Failure: please use only in Toolforge environment')
         exit(1)
 
 
@@ -200,7 +203,7 @@ def get_db_map(wikis=[], dbs=[]):
             db_map = {data[0]:data[1] for data in cur}
         conn.close()
     except pymysql.err.OperationalError as err:
-        print(err)
+        print('Failure: please use only in Toolforge environment')
         exit(1)
     
     return db_map, placeholders
@@ -274,7 +277,7 @@ def get_missed_contents(wikis):
             df = pd.DataFrame(cur, columns=['page_id', 'dbname'])
         conn.close()
     except pymysql.err.OperationalError as err:
-        print(err)
+        print('Failure: please use only in Toolforge environment')
         exit(1)
 
     df['wiki'] = df['dbname'].map(db_map)
@@ -293,7 +296,7 @@ def remove_missed_contents(wikis):
         conn.commit()
         conn.close()
     except pymysql.err.OperationalError as err:
-        print(err)
+        print('Failure: please use only in Toolforge environment')
         exit(1)
     
     print('Removed redundant rows.')


### PR DESCRIPTION
I believe reducing the 'gaplimit' solves the issue. Waiting for one final run, if no error occurs, we can move on.
Probably some pages had huge sourcecode and so it was causing memory error altho the number of pages was less.

Update: reducing gaplimit worked. I've also re-arranged the corn jobs to reduce time.

closes #7 