### PR TITLE
Working with the fetchers from both Toolforge and local pc

### DIFF
--- a/db_script.py
+++ b/db_script.py
@@ -25,7 +25,7 @@ def save_to_db(entries, db, user_db_port=None, user=None, password=None):
         conn.commit()
         conn.close()
     except pymysql.err.OperationalError:
-        print('Failure: please use only in Toolforge environment')
+        print('Failure: failure, please establish connection to Toolforge')
         exit(1)
 
 

--- a/db_script.py
+++ b/db_script.py
@@ -1,17 +1,23 @@
 import toolforge
 import pandas as pd
 import pymysql
+import argparse
+
 
 DATABASE_NAME = 's54588__data'
 
 
-def save_to_db(entries, db):
+def save_to_db(entries, db, user_db_port=None, user=None, password=None):
     query = ("insert into Scripts(dbname, page_id, title, in_database) "
              "             values(%s, %s, %s, %s)\n"
              "on duplicate key update in_database = %s"
              )
     try:
-        conn = toolforge.toolsdb(DATABASE_NAME)
+        if user_db_port:
+            conn = pymysql.connect(host='127.0.0.1', port=user_db_port,
+                                   user=user, password=password)
+        else:
+            conn = toolforge.toolsdb(DATABASE_NAME)
         with conn.cursor() as cur:
             for index, elem in entries.iterrows():
                 cur.execute(query,
@@ -29,34 +35,42 @@ def encode_if_necessary(b):
     return b
 
 
-def get_dbs():
+def get_dbs(user_db_port=None, user=None, password=None):
     try:
-        conn = toolforge.toolsdb(DATABASE_NAME)
+        if user_db_port:
+            conn = pymysql.connect(host='127.0.0.1', port=user_db_port,
+                                   user=user, password=password)
+        else:
+            conn = toolforge.toolsdb(DATABASE_NAME)
         with conn.cursor() as cur:
             cur.execute("select dbname from Sources where url is not NULL")    # all, except 'meta'
             ret = [db[0] for db in cur]
         conn.close()
         return ret
     except pymysql.err.OperationalError as err:
-        print('Failure: please use only in Toolforge environment')
+        print('Failure: failure, please establish connection to Toolforge')
         exit(1)
 
 
-def get_data(dbs):
+def get_data(dbs, replicas_port=None, user_db_port=None, user=None, password=None):
     ## Get all pages
     for db in dbs:
         try:
             ## Connect
-            conn = toolforge.connect(dbname=db)
+            if replicas_port:
+                conn = pymysql.connect(host='127.0.0.1', port=replicas_port,
+                                       user=user, password=password)
+            else:
+                conn = toolforge.connect(dbname=db)
             with conn.cursor() as cur:
                 ## Query
                 cur.execute("USE "+db+'_p')
                 SQL_Query = pd.read_sql_query("SELECT page_id,page_title FROM page \
                     WHERE page_content_model='Scribunto' AND page_namespace=828", conn)
-                df_page = pd.DataFrame(SQL_Query, columns=['page_id','page_title']).applymap(encode_if_necessary)
+                df_page = pd.DataFrame(SQL_Query, columns=['page_id', 'page_title']).applymap(encode_if_necessary)
 
                 # Saving to db
-                save_to_db(df_page, db)
+                save_to_db(df_page, db, user_db_port, user, password)
                 print('Finished loading scripts from ', db)
             conn.close()
         except Exception as err:
@@ -64,8 +78,31 @@ def get_data(dbs):
 
     print("Done loading from databases.")
 
+
 if __name__ == "__main__":
-    
-    dbs = get_dbs()
-    get_data(dbs)
-    
+    parser = argparse.ArgumentParser(
+        description="Updates wiki info stored in database in Toolforge. "
+                    "To use from local PC, use flag --local and all the additional flags needed for Ad"
+                    "establishing connection through ssh tunneling."
+                    "More help available at "
+                    "https://wikitech.wikimedia.org/wiki/Help:Toolforge/Database#SSH_tunneling_for_local_testing_which_makes_use_of_Wiki_Replica_databases"
+    )
+    parser.add_argument("--local", "-l", action="store_true",
+                        help="Connection is initiated from local pc.")
+    local_data = parser.add_argument_group(title="Info for connecting to Toolforge from local pc.")
+    local_data.add_argument("--replicas-port", "-r", type=int,
+                            help="Port for connecting to meta table through ssh tunneling, if used.")
+    local_data.add_argument("--user-db-port", "-udb", type=int,
+                            help="Port for connecting to local Sources table through ssh tunneling, if used.")
+    local_data.add_argument("--user", "-u", type=str,
+                            help="Toolforge username of the tool.")
+    local_data.add_argument("--password", "-p", type=str,
+                            help="Toolforge password of the tool.")
+    args = parser.parse_args()
+
+    if not args.local:
+        dbs = get_dbs()
+        get_data(dbs)
+    else:
+        dbs = get_dbs(args.user_db_port, args.user, args.password)
+        get_data(dbs, args.replicas_port, args.user_db_port, args.user, args.password)

--- a/db_script.py
+++ b/db_script.py
@@ -42,7 +42,7 @@ def get_dbs(user_db_port=None, user=None, password=None):
         conn.close()
         return ret
     except pymysql.err.OperationalError as err:
-        print('Failure: failure, please establish connection to Toolforge')
+        print('Failure: Please establish connection to Toolforge')
         exit(1)
 
 

--- a/db_script.py
+++ b/db_script.py
@@ -83,8 +83,8 @@ def get_data(dbs, replicas_port=None, user_db_port=None, user=None, password=Non
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Updates wiki info stored in database in Toolforge. "
-                    "To use from local PC, use flag --local and all the additional flags needed for Ad"
+        description="Updates Lua scripts in database in Toolforge, fetching info from database replicas. "
+                    "To use from local PC, use flag --local and all the additional flags needed for "
                     "establishing connection through ssh tunneling."
                     "More help available at "
                     "https://wikitech.wikimedia.org/wiki/Help:Toolforge/Database#SSH_tunneling_for_local_testing_which_makes_use_of_Wiki_Replica_databases"
@@ -95,7 +95,8 @@ if __name__ == "__main__":
     local_data.add_argument("--replicas-port", "-r", type=int,
                             help="Port for connecting to meta table through ssh tunneling, if used.")
     local_data.add_argument("--user-db-port", "-udb", type=int,
-                            help="Port for connecting to local Sources table through ssh tunneling, if used.")
+                            help="Port for connecting to tables, created by user in Toolforge, "
+                                 "through ssh tunneling, if used.")
     local_data.add_argument("--user", "-u", type=str,
                             help="Toolforge username of the tool.")
     local_data.add_argument("--password", "-p", type=str,

--- a/db_script.py
+++ b/db_script.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--local", "-l", action="store_true",
                         help="Connection is initiated from local pc.")
-    local_data = parser.add_argument_group(title="Info for connecting to Toolforge from local pc.")
+    local_data = parser.add_argument_group(title="Info for connecting to Toolforge from local pc")
     local_data.add_argument("--replicas-port", "-r", type=int,
                             help="Port for connecting to meta table through ssh tunneling, if used.")
     local_data.add_argument("--user-db-port", "-udb", type=int,

--- a/db_script.py
+++ b/db_script.py
@@ -23,7 +23,7 @@ def save_to_db(entries, db, user_db_port=None, user=None, password=None):
         conn.commit()
         conn.close()
     except pymysql.err.OperationalError:
-        print('Failure: failure, please establish connection to Toolforge')
+        print('Failure: Please establish connection to Toolforge')
         exit(1)
 
 

--- a/db_script.py
+++ b/db_script.py
@@ -19,6 +19,7 @@ def save_to_db(entries, db, user_db_port=None, user=None, password=None):
         else:
             conn = toolforge.toolsdb(DATABASE_NAME)
         with conn.cursor() as cur:
+            cur.execute("use " + DATABASE_NAME)
             for index, elem in entries.iterrows():
                 cur.execute(query,
                             [db, elem['page_id'], elem['page_title'], 1, 1])
@@ -43,7 +44,8 @@ def get_dbs(user_db_port=None, user=None, password=None):
         else:
             conn = toolforge.toolsdb(DATABASE_NAME)
         with conn.cursor() as cur:
-            cur.execute("select dbname from Sources where url is not NULL")    # all, except 'meta'
+            cur.execute("use " + DATABASE_NAME)
+            cur.execute("select dbname from Sources where url is not NULL")  # all, except 'meta'
             ret = [db[0] for db in cur]
         conn.close()
         return ret
@@ -64,7 +66,7 @@ def get_data(dbs, replicas_port=None, user_db_port=None, user=None, password=Non
                 conn = toolforge.connect(dbname=db)
             with conn.cursor() as cur:
                 ## Query
-                cur.execute("USE "+db+'_p')
+                cur.execute("USE " + db + '_p')
                 SQL_Query = pd.read_sql_query("SELECT page_id,page_title FROM page \
                     WHERE page_content_model='Scribunto' AND page_namespace=828", conn)
                 df_page = pd.DataFrame(SQL_Query, columns=['page_id', 'page_title']).applymap(encode_if_necessary)
@@ -74,7 +76,7 @@ def get_data(dbs, replicas_port=None, user_db_port=None, user=None, password=Non
                 print('Finished loading scripts from ', db)
             conn.close()
         except Exception as err:
-                print('Error loading pages from db: ', db, '\nError:', err)
+            print('Error loading pages from db: ', db, '\nError:', err)
 
     print("Done loading from databases.")
 

--- a/db_script.py
+++ b/db_script.py
@@ -22,8 +22,8 @@ def save_to_db(entries, db, user_db_port=None, user=None, password=None):
                             [db, elem['page_id'], elem['page_title'], 1, 1])
         conn.commit()
         conn.close()
-    except pymysql.err.OperationalError:
-        print('Failure: Please establish connection to Toolforge')
+    except Exception as err:
+        print('Something went wrong.\n', err)
         exit(1)
 
 
@@ -41,8 +41,8 @@ def get_dbs(user_db_port=None, user=None, password=None):
             ret = [db[0] for db in cur]
         conn.close()
         return ret
-    except pymysql.err.OperationalError as err:
-        print('Failure: Please establish connection to Toolforge')
+    except Exception as err:
+        print('Something went wrong.\n', err)
         exit(1)
 
 

--- a/fetch_content.py
+++ b/fetch_content.py
@@ -306,9 +306,9 @@ if __name__ == "__main__":
                     "More help available at "
                     "https://wikitech.wikimedia.org/wiki/Help:Toolforge/Database#SSH_tunneling_for_local_testing_which_makes_use_of_Wiki_Replica_databases"
     )
-    parser.add_argument("start-idx", type=index_type,
+    parser.add_argument("start_idx", type=index_type,
                         help="Starting index of info, fetched from database Sources, sorted by key (min=0).")
-    parser.add_argument("end-idx", type=index_type,
+    parser.add_argument("end_idx", type=index_type,
                         help="Ending index of info, fetched from database Sources, sorted by key.(min=0)")
     parser.add_argument("--revise", "-rev", action="store_true",
                         help="Whether content should be revised.")

--- a/fetch_content.py
+++ b/fetch_content.py
@@ -26,8 +26,8 @@ def get_wiki_list(start_idx, end_idx, user_db_port=None, user=None, password=Non
             ret = [wiki[0] for wiki in cur][start_idx:end_idx + 1]
         conn.close()
         return ret
-    except pymysql.err.OperationalError:
-        print('Failure: please use only in Toolforge environment')
+    except Exception as err:
+        print('Something went wrong.\n', err)
         exit(1)
 
 
@@ -57,9 +57,6 @@ def save_content(wiki, data_list, in_api, in_database, user_db_port=None, user=N
                              elem['content_model'], elem['lastrevid'], elem['url'], 0])
         conn.commit()
         conn.close()
-    except pymysql.err.OperationalError as err:
-        print('Failure: please use only in Toolforge environment')
-        exit(1)
     except Exception as err:
         print('Error saving pages from', wiki)
         print(err)
@@ -82,10 +79,9 @@ def save_missed_content(wiki, missed, user_db_port=None, user=None, password=Non
                             [dbname, elem['id'], 1, 1, 1, 1])
         conn.commit()
         conn.close()
-    except pymysql.err.OperationalError as err:
-        print('Failure: please use only in Toolforge environment')
+    except Exception as err:
+        print('Something went wrong.\n', err)
         exit(1)
-
 
 def needs_update(wiki, pageid, title, touched, revid):
     return True
@@ -206,8 +202,8 @@ def get_db_map(wikis=[], dbs=[], user_db_port=None, user=None, password=None):
             cur.execute(query, query_input)
             db_map = {data[0]: data[1] for data in cur}
         conn.close()
-    except pymysql.err.OperationalError as err:
-        print('Failure: please use only in Toolforge environment')
+    except Exception as err:
+        print('Something went wrong.\n', err)
         exit(1)
 
     return db_map, placeholders
@@ -280,8 +276,8 @@ def get_missed_contents(wikis, user_db_port=None, user=None, password=None):
             cur.execute(query, list(db_map.keys()))
             df = pd.DataFrame(cur, columns=['page_id', 'dbname'])
         conn.close()
-    except pymysql.err.OperationalError as err:
-        print('Failure: please use only in Toolforge environment')
+    except Exception as err:
+        print('Something went wrong.\n', err)
         exit(1)
 
     df['wiki'] = df['dbname'].map(db_map)

--- a/fetch_content.py
+++ b/fetch_content.py
@@ -315,7 +315,7 @@ if __name__ == "__main__":
 
     parser.add_argument("--local", "-l", action="store_true",
                         help="Connection is initiated from local pc.")
-    local_data = parser.add_argument_group(title="Info for connecting to Toolforge from local pc.")
+    local_data = parser.add_argument_group(title="Info for connecting to Toolforge from local pc")
     local_data.add_argument("--user-db-port", "-udb", type=int,
                             help="Port for connecting to tables, created by user in Toolforge, "
                                  "through ssh tunneling, if used.")

--- a/fetch_content.py
+++ b/fetch_content.py
@@ -316,8 +316,6 @@ if __name__ == "__main__":
     parser.add_argument("--local", "-l", action="store_true",
                         help="Connection is initiated from local pc.")
     local_data = parser.add_argument_group(title="Info for connecting to Toolforge from local pc.")
-    local_data.add_argument("--replicas-port", "-r", type=int,
-                            help="Port for connecting to meta table through ssh tunneling, if used.")
     local_data.add_argument("--user-db-port", "-udb", type=int,
                             help="Port for connecting to tables, created by user in Toolforge, "
                                  "through ssh tunneling, if used.")

--- a/fetch_content.py
+++ b/fetch_content.py
@@ -305,9 +305,9 @@ if __name__ == "__main__":
                     "https://wikitech.wikimedia.org/wiki/Help:Toolforge/Database#SSH_tunneling_for_local_testing_which_makes_use_of_Wiki_Replica_databases"
     )
     parser.add_argument("start-idx", type=index_type,
-                        help="Starting index of info, fetched from database Sources, sorted by key.")
+                        help="Starting index of info, fetched from database Sources, sorted by key (min=0).")
     parser.add_argument("end-idx", type=index_type,
-                        help="Ending index of info, fetched from database Sources, sorted by key.")
+                        help="Ending index of info, fetched from database Sources, sorted by key.(min=0)")
     parser.add_argument("--revise", "-rev", action="store_true",
                         help="Whether content should be revised.")
 

--- a/fetch_content.py
+++ b/fetch_content.py
@@ -7,20 +7,20 @@ import pymysql
 import numpy as np
 import argparse
 
+import utils.db_access as db_acc
 
 pymysql.converters.encoders[np.int64] = pymysql.converters.escape_int
 pymysql.converters.conversions = pymysql.converters.encoders.copy()
 pymysql.converters.conversions.update(pymysql.converters.decoders)
-
 
 ## define constants
 MIN_IDX = 0
 DATABASE_NAME = 's54588__data'
 
 
-def get_wiki_list(start_idx, end_idx):
+def get_wiki_list(start_idx, end_idx, user_db_port=None, user=None, password=None):
     try:
-        conn = toolforge.toolsdb(DATABASE_NAME)
+        conn = db_acc.connect_to_user_database(DATABASE_NAME, user_db_port, user, password)
         with conn.cursor() as cur:
             cur.execute("select url from Sources where url is not NULL")  # all, except 'meta'
             ret = [wiki[0] for wiki in cur][start_idx:end_idx + 1]
@@ -31,38 +31,41 @@ def get_wiki_list(start_idx, end_idx):
         exit(1)
 
 
-def save_content(wiki, data_list, in_api, in_database):
+def save_content(wiki, data_list, in_api, in_database, user_db_port=None, user=None, password=None):
+    data_df = pd.DataFrame(data_list,
+                           columns=['id', 'title', 'url', 'length', 'content', 'content_model', 'touched', 'lastrevid'])
 
-    data_df = pd.DataFrame(data_list, columns=['id', 'title', 'url', 'length', 'content', 'content_model', 'touched', 'lastrevid'])
-
-    query = ("insert into Scripts(dbname, page_id, title, sourcecode, touched, in_api, in_database, length, content_model, lastrevid, url) "
-             "             values(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)\n"
-             "on duplicate key update title = %s, sourcecode = %s, touched = %s, in_api = %s, in_database = %s,"
-             "length = %s, content_model = %s, lastrevid = %s, url = %s, is_missed=%s"
-             )
+    query = (
+        "insert into Scripts(dbname, page_id, title, sourcecode, touched,"
+        " in_api, in_database, length, content_model, lastrevid, url) "
+        "             values(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)\n"
+        "on duplicate key update title = %s, sourcecode = %s, touched = %s, in_api = %s, in_database = %s,"
+        "length = %s, content_model = %s, lastrevid = %s, url = %s, is_missed=%s"
+        )
     try:
-        conn = toolforge.toolsdb(DATABASE_NAME)
+        conn = db_acc.connect_to_user_database(DATABASE_NAME, user_db_port, user, password)
         with conn.cursor() as cur:
             cur.execute("select dbname from Sources where url = %s", wiki)
             dbname = cur.fetchone()[0]
             for index, elem in data_df.iterrows():
                 time = elem['touched'].replace('T', ' ').replace('Z', ' ')
                 cur.execute(query,
-                            [dbname, elem['id'], 
-                            elem['title'], elem['content'], time, in_api, in_database, elem['length'], elem['content_model'], elem['lastrevid'], elem['url'],
-                            elem['title'], elem['content'], time, in_api, in_database, elem['length'], elem['content_model'], elem['lastrevid'], elem['url'], 0])
+                            [dbname, elem['id'],
+                             elem['title'], elem['content'], time, in_api, in_database, elem['length'],
+                             elem['content_model'], elem['lastrevid'], elem['url'],
+                             elem['title'], elem['content'], time, in_api, in_database, elem['length'],
+                             elem['content_model'], elem['lastrevid'], elem['url'], 0])
         conn.commit()
         conn.close()
     except pymysql.err.OperationalError as err:
         print('Failure: please use only in Toolforge environment')
         exit(1)
     except Exception as err:
-        print('Error saving pages from',wiki)
+        print('Error saving pages from', wiki)
         print(err)
 
 
-def save_missed_content(wiki, missed):
-
+def save_missed_content(wiki, missed, user_db_port=None, user=None, password=None):
     missed_df = pd.DataFrame(missed, columns=['id'])
 
     query = ("insert into Scripts(dbname, page_id, in_api, is_missed) "
@@ -70,7 +73,7 @@ def save_missed_content(wiki, missed):
              "on duplicate key update in_api = %s, is_missed = %s"
              )
     try:
-        conn = toolforge.toolsdb(DATABASE_NAME)
+        conn = db_acc.connect_to_user_database(DATABASE_NAME, user_db_port, user, password)
         with conn.cursor() as cur:
             cur.execute("select dbname from Sources where url = %s", wiki)
             dbname = cur.fetchone()[0]
@@ -88,7 +91,7 @@ def needs_update(wiki, pageid, title, touched, revid):
     return True
 
 
-def get_contents(wikis, revise=False):
+def get_contents(wikis, revise=False, user_db_port=None, user=None, password=None):
     '''
     revise: `False` collects all contents and saves fresh
             `True` only collects those that have been edited
@@ -114,23 +117,23 @@ def get_contents(wikis, revise=False):
         _continue = ''
 
         while True:
-            params = {'action':'query',
-                    'generator':'allpages',
-                    'gapnamespace':828,
-                    'gaplimit':300,
-                    'format':'json',
-                    'prop':'info',
-                    'inprop':'url',
-                    'gapcontinue': _gapcontinue,
-                    'continue': _continue,
-                    }
-            
+            params = {'action': 'query',
+                      'generator': 'allpages',
+                      'gapnamespace': 828,
+                      'gaplimit': 300,
+                      'format': 'json',
+                      'prop': 'info',
+                      'inprop': 'url',
+                      'gapcontinue': _gapcontinue,
+                      'continue': _continue,
+                      }
+
             try:
                 result = session.get(params)
             except Exception as e:
                 print("Could not GET", wiki, "\n", e)
                 break
-            
+
             if 'query' in result.keys():
                 for page in list(result['query']['pages'].values()):
                     try:
@@ -140,54 +143,53 @@ def get_contents(wikis, revise=False):
                         length = page['length']
                         url = page['fullurl']
                         revid = page['lastrevid']
-                        
+
                         if (not revise) or needs_update(wiki, pageid, title, touched, revid):
-                            params = {'action':'query',
-                                    'format':'json',
-                                    'prop':'revisions',
-                                    'revids':revid,
-                                    'rvprop':'content',
-                                    'rvslots':'main',
-                                    'formatversion':2
-                                    }
-                    
+                            params = {'action': 'query',
+                                      'format': 'json',
+                                      'prop': 'revisions',
+                                      'revids': revid,
+                                      'rvprop': 'content',
+                                      'rvslots': 'main',
+                                      'formatversion': 2
+                                      }
+
                             rev_result = session.get(params)
 
                             content_info = rev_result['query']['pages'][0]['revisions'][0]['slots']['main']
                             content = content_info['content']
                             content_model = content_info['contentmodel']
-                            
-                            if content_model=='Scribunto':
+
+                            if content_model == 'Scribunto':
                                 data_list.append([pageid, title, url, length, content, content_model, touched, revid])
                     except Exception as err:
                         if 'pageid' in page.keys():
                             missed.append([pageid])
-                            print("Miss:", wiki, title, pageid, "\n" ,err)
-            
+                            print("Miss:", wiki, title, pageid, "\n", err)
+
                 cnt_data_list += len(data_list)
                 cnt_missed += len(missed)
-                save_missed_content(wiki, missed)
-                save_content(wiki, data_list, 1, 0)
+                save_missed_content(wiki, missed, user_db_port, user, password)
+                save_content(wiki, data_list, 1, 0, user_db_port, user, password)
                 print(cnt_data_list, 'pages loaded...')
                 data_list, missed = [], []
 
             try:
                 _continue = result['continue']['continue']
-                _gapcontinue = result['continue']['gapcontinue'] if 'gapcontinue' in  result['continue'] else ''
+                _gapcontinue = result['continue']['gapcontinue'] if 'gapcontinue' in result['continue'] else ''
             except:
                 break
 
         print("All pages loaded for %s. Missed: %d, Loaded: %d" \
-            %(wiki, cnt_missed, cnt_data_list))
-    
+              % (wiki, cnt_missed, cnt_data_list))
+
     print("Done loading!")
 
 
-def get_db_map(wikis=[], dbs=[]):
-    
+def get_db_map(wikis=[], dbs=[], user_db_port=None, user=None, password=None):
     query_input = []
-    
-    if len(wikis)>0:
+
+    if len(wikis) > 0:
         placeholders = ','.join('%s' for _ in wikis)
         query_input = wikis
         query = ("select dbname, url from Sources where url in (%s)" % placeholders)
@@ -195,23 +197,23 @@ def get_db_map(wikis=[], dbs=[]):
         placeholders = ','.join('%s' for _ in dbs)
         query_input = dbs
         query = ("select dbname, url from Sources where dbname in (%s)" % placeholders)
-    
+
     db_map = {}
 
     try:
-        conn = toolforge.toolsdb(DATABASE_NAME)
+        conn = db_acc.connect_to_user_database(DATABASE_NAME, user_db_port, user, password)
         with conn.cursor() as cur:
-            cur.execute(query,query_input)
-            db_map = {data[0]:data[1] for data in cur}
+            cur.execute(query, query_input)
+            db_map = {data[0]: data[1] for data in cur}
         conn.close()
     except pymysql.err.OperationalError as err:
         print('Failure: please use only in Toolforge environment')
         exit(1)
-    
+
     return db_map, placeholders
 
 
-def get_pages(df, in_api, in_database):
+def get_pages(df, in_api, in_database, user_db_port=None, user=None, password=None):
     '''
     df columns: page_id, dbname, wiki
     dbname not required
@@ -223,27 +225,27 @@ def get_pages(df, in_api, in_database):
         except Exception as e:
             print("Failed to connect to", wiki, "\n", e)
             continue
-            
+
         pageids = w_df['page_id'].values
         data_list = []
         missed = []
-        
+
         for pageid in list(pageids):
             params = {
-                'action':'query',
-                'format':'json',
-                'prop':'revisions|info',
-                'pageids':pageid,
-                'rvprop':'content',
-                'rvslots':'main',
-                'inprop':'url',
-                'formatversion':2
+                'action': 'query',
+                'format': 'json',
+                'prop': 'revisions|info',
+                'pageids': pageid,
+                'rvprop': 'content',
+                'rvslots': 'main',
+                'inprop': 'url',
+                'formatversion': 2
             }
 
             try:
                 result = session.get(params)
                 page = result['query']['pages'][0]
-                if page['lastrevid']!=0:
+                if page['lastrevid'] != 0:
                     url = page['fullurl']
                     title = page['title']
                     length = page['length']
@@ -252,28 +254,28 @@ def get_pages(df, in_api, in_database):
                     content_model = content_info['contentmodel']
                     touched = page['touched']
                     revid = page['lastrevid']
-                    
-                    if content_model=='Scribunto':
+
+                    if content_model == 'Scribunto':
                         data_list.append([pageid, title, url, length, content, content_model, touched, revid])
             except Exception as err:
                 missed.append([pageid])
                 print("Miss:", pageid, "from wiki:", wiki, "\n", err)
 
-        save_content(wiki, data_list, in_api, in_database)
-        save_missed_content(wiki, missed)
+        save_content(wiki, data_list, in_api, in_database, user_db_port, user, password)
+        save_missed_content(wiki, missed, user_db_port, user, password)
         print("All pages loaded for %s. Missed: %d, Loaded: %d" \
-            %(wiki, len(missed), len(data_list)))
+              % (wiki, len(missed), len(data_list)))
 
 
-def get_missed_contents(wikis):
-
+def get_missed_contents(wikis, user_db_port=None, user=None, password=None):
     print("Started loading missed contents...")
 
-    db_map, placeholders = get_db_map(wikis=wikis)
+    db_map, placeholders = get_db_map(wikis=wikis, user_db_port=user_db_port,
+                                      user=user, password=password)
     query = ("select page_id, dbname from Scripts where dbname in (%s) and in_api=1 and is_missed=1" % placeholders)
-    
+
     try:
-        conn = toolforge.toolsdb(DATABASE_NAME)
+        conn = db_acc.connect_to_user_database(DATABASE_NAME, user_db_port, user, password)
         with conn.cursor() as cur:
             cur.execute(query, list(db_map.keys()))
             df = pd.DataFrame(cur, columns=['page_id', 'dbname'])
@@ -330,7 +332,9 @@ if __name__ == "__main__":
 
     if not args.local:
         wikis = get_wiki_list(args.start_idx, args.end_idx)
-        get_contents(wikis)
+        get_contents(wikis, args.revise)
         get_missed_contents(wikis=wikis)
     else:
-        pass
+        wikis = get_wiki_list(args.start_idx, args.end_idx, args.user_db_port, args.user, args.password)
+        get_contents(wikis, args.revise, args.user_db_port, args.user, args.password)
+        get_missed_contents(wikis, args.user_db_port, args.user, args.password)

--- a/utils/db_access.py
+++ b/utils/db_access.py
@@ -22,8 +22,9 @@ def connect_to_user_database(db_name, user_db_port=None, user=None, password=Non
             conn = toolforge.toolsdb(db_name)
 
         return conn
-    except pymysql.err.OperationalError:
+    except pymysql.err.OperationalError as err:
         print('Failure: failure, please establish connection to Toolforge')
+        print('Error: ', err)
         exit(1)
 
 
@@ -47,6 +48,7 @@ def connect_to_replicas_database(db_name, replicas_port=None, user=None, passwor
             conn = toolforge.connect(dbname=db_name)
 
         return conn
-    except pymysql.err.OperationalError:
+    except pymysql.err.OperationalError as err:
         print('Failure: failure, please establish connection to Toolforge')
+        print('Error: ', err)
         exit(1)

--- a/utils/db_access.py
+++ b/utils/db_access.py
@@ -23,7 +23,7 @@ def connect_to_user_database(db_name, user_db_port=None, user=None, password=Non
 
         return conn
     except pymysql.err.OperationalError as err:
-        print('Failure: failure, please establish connection to Toolforge')
+        print('Failure: Please establish connection to Toolforge')
         print('Error: ', err)
         exit(1)
 
@@ -49,6 +49,6 @@ def connect_to_replicas_database(db_name, replicas_port=None, user=None, passwor
 
         return conn
     except pymysql.err.OperationalError as err:
-        print('Failure: failure, please establish connection to Toolforge')
+        print('Failure: Please establish connection to Toolforge')
         print('Error: ', err)
         exit(1)

--- a/utils/db_access.py
+++ b/utils/db_access.py
@@ -1,0 +1,52 @@
+import pymysql
+import toolforge
+
+
+def connect_to_user_database(db_name, user_db_port=None, user=None, password=None):
+    """
+    Establishes connection to database, created by user, in Toolforge.
+    :param db_name: name of user's database
+    :param user_db_port: port for connecting to db through ssh tunneling, if used
+    :param user: Toolforge username of the tool
+    :param password: Toolforge password pf the tool
+    :return: pymysql.connection to the database
+    """
+    try:
+        if user_db_port:
+            conn = pymysql.connect(host='127.0.0.1', port=user_db_port,
+                                   user=user, password=password)
+            with conn.cursor() as cur:
+                cur.execute("use " + db_name)
+            conn.commit()
+        else:
+            conn = toolforge.toolsdb(db_name)
+
+        return conn
+    except pymysql.err.OperationalError:
+        print('Failure: failure, please establish connection to Toolforge')
+        exit(1)
+
+
+def connect_to_replicas_database(db_name, replicas_port=None, user=None, password=None):
+    """
+    Establishes connection to Wikimedia replicas database in Toolforge.
+    :param db_name: name of the database
+    :param replicas_port: port for connecting to db through ssh tunneling, if used
+    :param user: Toolforge username of the tool
+    :param password: Toolforge password pf the tool
+    :return: pymysql.connection to the database
+    """
+    try:
+        if replicas_port:
+            conn = pymysql.connect(host='127.0.0.1', port=replicas_port,
+                                   user=user, password=password)
+            with conn.cursor() as cur:
+                cur.execute("use " + db_name)
+            conn.commit()
+        else:
+            conn = toolforge.connect(dbname=db_name)
+
+        return conn
+    except pymysql.err.OperationalError:
+        print('Failure: failure, please establish connection to Toolforge')
+        exit(1)

--- a/wikis_parser.py
+++ b/wikis_parser.py
@@ -157,10 +157,11 @@ if __name__ == '__main__':
     parser.add_argument("--local", "-l", action="store_true",
                         help="Connection is initiated from local pc.")
     local_data = parser.add_argument_group(title="Info for connecting to Toolforge from local pc.")
-    local_data.add_argument("--meta-port", "-m", type=int,
+    local_data.add_argument("--replicas-port", "-r", type=int,
                             help="Port for connecting to meta table through ssh tunneling, if used.")
-    local_data.add_argument("--sources-port", "-s", type=int,
-                            help="Port for connecting to local Sources table through ssh tunneling, if used.")
+    local_data.add_argument("--user-db-port", "-udb", type=int,
+                            help="Port for connecting to tables, created by user in Toolforge, "
+                                 "through ssh tunneling, if used.")
     local_data.add_argument("--user", "-u", type=str,
                             help="Toolforge username of the tool.")
     local_data.add_argument("--password", "-p", type=str,
@@ -170,4 +171,4 @@ if __name__ == '__main__':
     if not args.local:
         update_checker()
     else:
-        update_checker(args.meta_port, args.sources_port, args.user, args.password)
+        update_checker(args.replicas_port, args.user_db_port, args.user, args.password)

--- a/wikis_parser.py
+++ b/wikis_parser.py
@@ -73,6 +73,7 @@ def save_links_to_db(entries, sources_port=None, user=None, password=None):
         else:
             conn = toolforge.toolsdb(DATABASE_NAME)
         with conn.cursor() as cur:
+            cur.execute("use " + DATABASE_NAME)
             for elem in entries:
                 cur.execute(query, [elem[0], elem[1], elem[1]])
         conn.commit()
@@ -112,6 +113,7 @@ def get_last_update_local_db(sources_port=None, user=None, password=None):
         else:
             conn = toolforge.toolsdb(DATABASE_NAME)
         with conn.cursor() as cur:
+            cur.execute("use " + DATABASE_NAME)
             cur.execute(query)
             update_time = cur.fetchone()
         return update_time
@@ -157,6 +159,7 @@ def _update_local_db(update_time, sources_port=None, user=None, password=None):
             conn = toolforge.toolsdb(DATABASE_NAME)
         with conn.cursor() as cur:
             time = update_time.strftime('%Y-%m-%d %H:%M:%S')
+            cur.execute("use " + DATABASE_NAME)
             cur.execute(query, [time, time])
         conn.commit()
         conn.close()

--- a/wikis_parser.py
+++ b/wikis_parser.py
@@ -58,7 +58,7 @@ def get_creation_date_from_db(meta_port=None, user=None, password=None):
             time = cur.fetchone()[0]
             return time
     except pymysql.err.OperationalError:
-        print('Wikiprojects update checker: failure, please use only in Toolforge environment')
+        print('Wikiprojects update checker: failure, please establish connection to Toolforge')
         exit(1)
 
 
@@ -87,7 +87,7 @@ def save_links_to_db(entries, sources_port=None, user=None, password=None):
         conn.commit()
         conn.close()
     except pymysql.err.OperationalError:
-        print('Wikiprojects update checker: failure, please use only in Toolforge environment')
+        print('Wikiprojects update checker: failure, please establish connection to Toolforge')
         exit(1)
 
 
@@ -118,7 +118,7 @@ def get_last_update_local_db(sources_port=None, user=None, password=None):
             update_time = cur.fetchone()[0]
             return update_time
     except pymysql.err.OperationalError:
-        print('Wikiprojects update checker: failure, please use only in Toolforge environment')
+        print('Wikiprojects update checker: failure, please establish connection to Toolforge')
         exit(1)
 
 
@@ -148,7 +148,7 @@ def update_local_db(update_time, sources_port=None, user=None, password=None):
         conn.commit()
         conn.close()
     except pymysql.err.OperationalError:
-        print('Wikiprojects update checker: failure, please use only in Toolforge environment')
+        print('Wikiprojects update checker: failure, please establish connection to Toolforge')
         exit(1)
 
 

--- a/wikis_parser.py
+++ b/wikis_parser.py
@@ -48,8 +48,8 @@ def get_creation_date_from_db(replicas_port=None, user=None, password=None):
             cur.execute(query)
             time = cur.fetchone()[0]
             return time
-    except pymysql.err.OperationalError:
-        print('Wikiprojects update checker: failure, please establish connection to Toolforge')
+    except Exception as err:
+        print('Something went wrong.\n', err)
         exit(1)
 
 
@@ -72,8 +72,8 @@ def save_links_to_db(entries, user_db_port=None, user=None, password=None):
                 cur.execute(query, [elem[0], elem[1], elem[1]])
         conn.commit()
         conn.close()
-    except pymysql.err.OperationalError:
-        print('Wikiprojects update checker: failure, please establish connection to Toolforge')
+    except Exception as err:
+        print('Something went wrong.\n', err)
         exit(1)
 
 
@@ -98,8 +98,8 @@ def get_last_update_local_db(user_db_port=None, user=None, password=None):
             cur.execute(query)
             update_time = cur.fetchone()[0]
             return update_time
-    except pymysql.err.OperationalError:
-        print('Wikiprojects update checker: failure, please establish connection to Toolforge')
+    except Exception as err:
+        print('Something went wrong.\n', err)
         exit(1)
 
 
@@ -123,8 +123,8 @@ def update_local_db(update_time, user_db_port=None, user=None, password=None):
             cur.execute(query, [time, time])
         conn.commit()
         conn.close()
-    except pymysql.err.OperationalError:
-        print('Wikiprojects update checker: failure, please establish connection to Toolforge')
+    except Exception as err:
+        print('Something went wrong.\n', err)
         exit(1)
 
 

--- a/wikis_parser.py
+++ b/wikis_parser.py
@@ -29,6 +29,7 @@ def get_wikipages_from_db(meta_port=None, user=None, password=None):
     else:
         conn = toolforge.connect('meta')
     with conn.cursor() as cur:
+        cur.execute("use meta_p;")
         cur.execute(query)
         return cur.fetchall()
 
@@ -50,6 +51,7 @@ def get_creation_date_from_db(meta_port=None, user=None, password=None):
         else:
             conn = toolforge.connect('meta')
         with conn.cursor() as cur:
+            cur.execute("use meta_p;")
             cur.execute(query)
             return cur.fetchone()[0]
     except pymysql.err.OperationalError:

--- a/wikis_parser.py
+++ b/wikis_parser.py
@@ -156,7 +156,7 @@ if __name__ == '__main__':
     )
     parser.add_argument("--local", "-l", action="store_true",
                         help="Connection is initiated from local pc.")
-    local_data = parser.add_argument_group(title="Info for connecting to Toolforge from local pc.")
+    local_data = parser.add_argument_group(title="Info for connecting to Toolforge from local pc")
     local_data.add_argument("--replicas-port", "-r", type=int,
                             help="Port for connecting to meta table through ssh tunneling, if used.")
     local_data.add_argument("--user-db-port", "-udb", type=int,


### PR DESCRIPTION
Hi, @tanny411 please look at the modifications to the code I made. All the necessary ports and user-password pair now can be given to the scripts to work with databases through ssh. Everything is documented with argparse and `python3 <script_name> -h` will return help info to understand it's usage better.